### PR TITLE
VS2013 requires return type for auto

### DIFF
--- a/peglib.h
+++ b/peglib.h
@@ -193,7 +193,7 @@ private:
 };
 
 template <typename EF>
-auto make_scope_exit(EF&& exit_function) {
+auto make_scope_exit(EF&& exit_function) -> scope_exit<EF> {
     return scope_exit<std::remove_reference_t<EF>>(std::forward<EF>(exit_function));
 }
 


### PR DESCRIPTION
Hi Yuji. 

Yes, removing noexcept is fine for VS2013. I ha to make one minor change so that VS can discern the return type. 