### PR TITLE
Backporting "undefined reference to peg::enabler"

### DIFF
--- a/peglib.h
+++ b/peglib.h
@@ -41,8 +41,8 @@
 
 namespace peg {
 
-#if __clang__ == 1 && __clang_major__ == 5 && __clang_minor__ == 0 && __clang_patchlevel__ == 0
-static void* enabler = nullptr; // workaround for Clang 5.0.0
+#if __clang__ == 1 && __clang_major__ <= 5
+static void* enabler = nullptr; // workaround for Clang version <= 5.0.0
 #else
 extern void* enabler;
 #endif
@@ -2076,7 +2076,7 @@ private:
             }
         };
 
-        g["Primary"] = [&](const SemanticValues& sv, any& dt) {
+        g["Primary"] = [&](const SemanticValues& sv, any& dt) -> std::shared_ptr<Ope> {
             Data& data = *dt.get<Data*>();
 
             switch (sv.choice()) {


### PR DESCRIPTION
Compilation using clang 3.5.2 results in an error fixed in #29. As the problem will probably exist in all clang versions older than v5 it may be better to change the check to include all older versions instead of adding another exact one (i.e. 3.5.2). Another minor fix enables tests to compile with clang 3.5.2 - without it lambda return type deduction fails.

Signed-off-by: Remigiusz Kołłątaj <remigiusz.kollataj@mobica.com>