### PR TITLE
Update peglib.h

### DIFF
--- a/peglib.h
+++ b/peglib.h
@@ -30,7 +30,7 @@
 #define PEGLIB_NO_CONSTEXPR_SUPPORT
 #elif (_MSC_VER >= 1800)
 // good to go
-#else (_MSC_VER < 1800)
+#else //(_MSC_VER < 1800)
 #error "Requires C+11 support"
 #endif
 #endif


### PR DESCRIPTION
This '#else' directive does not have such extra condition in C++.
A static code analyzer including VC warns it.