### PR TITLE
Fix maybe uninitialized warning / error

### DIFF
--- a/peglib.h
+++ b/peglib.h
@@ -1323,7 +1323,7 @@ public:
             return static_cast<size_t>(-1);
         }
 
-        char32_t cp;
+        char32_t cp = 0;
         auto len = decode_codepoint(s, n, cp);
 
         if (!ranges_.empty()) {


### PR DESCRIPTION
Hi, I'm getting a warning / error with GCC 9, complaining about the possibility of `cp` being uninitialized in the if statement in L1331. `decode_codepoint` should be writing to `cp`, but apparently GCC sees a code path leading to `decode_codepoint` returning without setting a value (maybe for invalid unicode?). Silence this error by initializing `cp` to zero?
https://github.com/yhirose/cpp-peglib/blob/c0d2318b1582b0679618d53ede8bf9c98d7f06c8/peglib.h#L1326-L1331