### PR TITLE
Fix for u8 char C++20 incompatibility

### DIFF
--- a/peglib.h
+++ b/peglib.h
@@ -3035,7 +3035,7 @@ private:
                          cls("0-9a-fA-F"), cls("0-9a-fA-F")),
                      seq(npd(chr('\\')), dot()));
 
-    g["LEFTARROW"] <= seq(cho(lit("<-"), lit(u8"←")), g["Spacing"]);
+    g["LEFTARROW"] <= seq(cho(lit("<-"), lit(reinterpret_cast<const char*>(u8"←"))), g["Spacing"]);
     ~g["SLASH"] <= seq(chr('/'), g["Spacing"]);
     ~g["PIPE"] <= seq(chr('|'), g["Spacing"]);
     g["AND"] <= seq(chr('&'), g["Spacing"]);


### PR DESCRIPTION
C++20 apparently doesn't allow std::string construction from u8 literals any more.
The pre-20 behavior is restored by explicitly casting the new `char_8_t` back to `char`.