### PR TITLE
Fix missing return statement in lambda

### DIFF
--- a/peglib.h
+++ b/peglib.h
@@ -3138,6 +3138,8 @@ private:
         case Loop::Type::oom: return oom(ope);
         case Loop::Type::rep: // Regex-like repetition
           return rep(ope, loop.range.first, loop.range.second);
+        default:
+          throw std::runtime_error("Unhandled enum constant");
         }
       }
     };


### PR DESCRIPTION
This PR fixes a warning with g++ 9.0 and handles, when e.g. an element is added to `Loop::Type` without adapting the switch-statement.

It will fix https://github.com/yhirose/cpp-peglib/issues/98