### PR TITLE
Fix "terminate called after throwing an instance of 'std::system_error'"

### DIFF
--- a/lint/CMakeLists.txt
+++ b/lint/CMakeLists.txt
@@ -3,3 +3,7 @@ project(peglint)
 include_directories(..)
 add_definitions("-std=c++11")
 add_executable(peglint peglint.cc)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_libraries(peglint pthread)
+endif()


### PR DESCRIPTION
This is a re-fix.  The missing pthread lib was fixed in 469a61f0440ecd0e1eca4f390b62a4e32d3db3a7, but then unfixed in 06fc879371cb81a1b2920896c2ddb1b66b8fbb13.