### PR TITLE
Use CMake's Threads library to provide '-pthread` for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.1.0)
 project("cpp-peglib")
 
+find_package(Threads)
 # Check if a supported compiler is used to setup the C++ standard to use:
 get_property(known_features GLOBAL PROPERTY CMAKE_CXX_KNOWN_FEATURES)
 list(FIND known_features "cxx_std_17" found)
@@ -31,7 +32,7 @@ elseif(MSVC)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  set(add_link_deps pthread)
+  set(add_link_deps Threads::Threads)
 endif()
 
 enable_testing()

--- a/lint/CMakeLists.txt
+++ b/lint/CMakeLists.txt
@@ -5,5 +5,5 @@ add_definitions("-std=c++11")
 add_executable(peglint peglint.cc)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  target_link_libraries(peglint pthread)
+  target_link_libraries(peglint ${add_link_deps})
 endif()


### PR DESCRIPTION
For linux platform, we may use the Threads library to provide
the option `-pthread` when the program uses multiple thread. This
solution is portable for WSL2/Linux and other disturbuiton.