### PR TITLE
Add -config.cmake file to installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1.0)
-project("cpp-peglib")
+project(cpp-peglib VERSION "1.3.7")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -17,6 +17,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(add_link_deps Threads::Threads)
 endif()
 
+##############
+# Installation paths
+set(INCLUDE_INSTALL_DIR include/ CACHE PATH "Installation directory for C++ headers")
+set(LIB_INSTALL_DIR lib${LIB_SUFFIX}/ CACHE PATH "Installation directory for libraries")
+
 add_subdirectory(example)
 add_subdirectory(lint)
 
@@ -24,3 +29,27 @@ add_subdirectory(test)
 enable_testing()
 
 install(FILES peglib.h DESTINATION include)
+
+##########
+# Generate -config.cmake file
+# This file will allow to link to this library (peglib.h) with cmake find_package
+
+# Install destination to -config.cmake
+set(INSTALL_DESTINATION_PATH ${LIB_INSTALL_DIR}/cmake/${PROJECT_NAME}${MSVCARCH_DIR_EXTENSION_EXT})
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/packaging/Config.cmake.in
+    ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION ${INSTALL_DESTINATION_PATH}
+    PATH_VARS INCLUDE_INSTALL_DIR
+)
+write_basic_package_version_file(${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config.cmake
+    ${PROJECT_BINARY_DIR}/cmake/config/${PROJECT_NAME}-config-version.cmake
+    DESTINATION ${INSTALL_DESTINATION_PATH}
+    COMPONENT cmake
+)

--- a/cmake/packaging/Config.cmake.in
+++ b/cmake/packaging/Config.cmake.in
@@ -1,0 +1,19 @@
+# Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(@PROJECT_NAME@_VERSION @PROJECT_VERSION@)
+
+@PACKAGE_INIT@
+
+set_and_check(@PROJECT_NAME@_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")


### PR DESCRIPTION
This PR adds the `-config.cmake` file to the project.
This file is very useful to link this project from others using `find_package(cpp-peglib)`.
This `find_package` will populate `${cpp-peglib_INCLUDE_DIR}` with the path to the include in install.

Signed-off-by: jparisu <javierparis@eprosima.com>