### PR TITLE
Add cmake toggle to disable tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ endif()
 
 add_subdirectory(example)
 add_subdirectory(lint)
-add_subdirectory(test)
+# add_subdirectory(test)
 
-enable_testing()
+# enable_testing()
 
 install(FILES peglib.h DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 endif()
 
-option(PEGLIB_BUILD_TESTS "Build cpp-peglib tests" OFF)
+option(PEGLIB_BUILD_TESTS "Build cpp-peglib tests" ON)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 endif()
 
+option(PEGLIB_BUILD_TESTS "Build cpp-peglib tests" OFF)
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads)
 
@@ -19,8 +21,10 @@ endif()
 
 add_subdirectory(example)
 add_subdirectory(lint)
-# add_subdirectory(test)
 
-# enable_testing()
+if (${PEGLIB_BUILD_TESTS})
+  add_subdirectory(test)
+  enable_testing()
+endif()
 
 install(FILES peglib.h DESTINATION include)


### PR DESCRIPTION
Building tests by default is not necessary, so I added a cmake `option()` command `PEGLIB_BUILD_TESTS` that can be used to toggle this on or off (default value is OFF).