### PR TITLE
Avoid requiring pthread on Linux distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.14)
 project(cpp-peglib)
 
+# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
+# Fix found at https://github.com/ethereum/solidity/pull/13429
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -11,18 +17,17 @@ else()
 endif()
 
 option(PEGLIB_BUILD_TESTS "Build cpp-peglib tests" ON)
+option(PEGLIB_BUILD_LINT "Build cpp-peglib lint" ON)
+option(PEGLIB_BUILD_EXAMPLE "Build cpp-peglib examples" ON)
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads)
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  set(add_link_deps Threads::Threads)
+if(${PEGLIB_BUILD_LINT})
+add_subdirectory(lint)
 endif()
 
-add_subdirectory(lint)
-
+if(${PEGLIB_BUILD_EXAMPLE})
 add_subdirectory(example)
 # add_subdirectory(cymbol)
+endif()
 
 if (${PEGLIB_BUILD_TESTS})
   add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ The PEG syntax is well described on page 2 in the [document](http://www.brynosau
 
 This library supports the linear-time parsing known as the [*Packrat*](http://pdos.csail.mit.edu/~baford/packrat/thesis/thesis.pdf) parsing.
 
-  IMPORTANT NOTE for some Linux distributions such as Ubuntu and CentOS: Need `-pthread` option when linking. See [#23](https://github.com/yhirose/cpp-peglib/issues/23#issuecomment-261126127), [#46](https://github.com/yhirose/cpp-peglib/issues/46#issuecomment-417870473) and [#62](https://github.com/yhirose/cpp-peglib/issues/62#issuecomment-492032680).
-
 How to use
 ----------
 

--- a/peglib.h
+++ b/peglib.h
@@ -52,7 +52,7 @@ namespace peg {
 
 using once_flag = bool;
 
-template <class Callable, class... Args>
+template <class Callable>
 void call_once(once_flag& flag, Callable&& f) {
   if(!flag) {
     flag = true;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.14)
 project(test)
 
+# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
+# Fix found at https://github.com/ethereum/solidity/pull/13429
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 include(FetchContent)
 FetchContent_Declare(
   googletest


### PR DESCRIPTION
Hi,

I ran into problems trying this library on Ubuntu, and even after linking to pthread I couldn't run my example :(
Since you are not using threads anyways, I thought we could eliminate the problem by simply redefining (a simpler version of) `call_once` and `once_flag`.
I removed the warning in the README, and the pthread thing in the CMake.

Besides, I've added some flags to allow developers importing your library through CMake to disable the builds of example and lint.
There was also a warning on CMake version > 3.24 that required a fix.