### PR TITLE
Peglib as a CMake target

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,7 +33,8 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source
       # and build directories, but this is only available with CMake 3.13 and higher.
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+        -DPEGLIB_BUILD_TESTS=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,9 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 endif()
 
-option(BUILD_TESTS "Build cpp-peglib tests" ON)
+option(PEGLIB_BUILD_TESTS "Build cpp-peglib tests" OFF)
+option(PEGLIB_BUILD_LINT "Build cpp-peglib lint utility" OFF)
+option(PEGLIB_BUILD_EXAMPLES "Build cpp-peglib examples" OFF)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads)
@@ -19,10 +21,16 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(add_link_deps Threads::Threads)
 endif()
 
-add_subdirectory(lint)
+add_library(Peglib INTERFACE)
+target_include_directories(Peglib INTERFACE ${CMAKE_SOURCE_DIR})
 
-add_subdirectory(example)
-# add_subdirectory(cymbol)
+if(${PEGLIB_BUILD_LINT})
+  add_subdirectory(lint)
+endif()
+
+if(${PEGLIB_BUILD_EXAMPLES})
+  add_subdirectory(example)
+endif()
 
 if (${BUILD_TESTS})
   add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(${PEGLIB_BUILD_EXAMPLES})
   add_subdirectory(example)
 endif()
 
-if (${BUILD_TESTS})
+if (${PEGLIB_BUILD_TESTS})
   add_subdirectory(test)
   enable_testing()
 endif()

--- a/README.md
+++ b/README.md
@@ -755,6 +755,37 @@ Sample codes
   * [A tiny PL/0 JIT compiler in less than 900 LOC with LLVM and PEG parser](https://github.com/yhirose/pl0-jit-compiler)
   * [A Programming Language just for writing Fizz Buzz program. :)](https://github.com/yhirose/fizzbuzzlang)
 
+CMake integration
+------------
+
+To build tests, examples or lint utility, pass `-DPEGLIB_BUILD_TESTS=ON`, 
+`-DPEGLIB_BUILD_EXAMPLES=ON` or `-DPEGLIB_BUILD_LINT=ON` to cmake 
+configuration command respectively.
+
+
+### Using with FetchContent
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+    Peglib
+    GIT_REPOSITORY https://github.com/yhirose/cpp-peglib
+    GIT_TAG v1.8.3
+)
+
+FetchContent_MakeAvailable(Peglib)
+
+target_include_directories(<Your-Target> Peglib)
+```
+
+### Installation
+
+```sh
+cmake -S . -B build
+cmake --build build --target install
+```
+
 License
 -------
 


### PR DESCRIPTION
It is not comfortable to use a library with FetchContent module, when the library is not specified as a target, so I added `add_library(peglib INTERFACE)`. Also I added options to conditionally build tests, lint and examples, which are not building by default, modified `.github/workflows/cmake.yml` to build tests, and added a section about CMake into `README.md`.