### PR TITLE
check c++ version correctly under MSVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ cpp-peglib
 
 C++17 header-only [PEG](http://en.wikipedia.org/wiki/Parsing_expression_grammar) (Parsing Expression Grammars) library. You can start using it right away just by including `peglib.h` in your project.
 
-Since this library only supports C++17 compilers, please make sure that compiler the option `-std=c++17` is enabled. (`/std:c++17 /Zc:__cplusplus` for MSVC)
+Since this library only supports C++17 compilers, please make sure that compiler the option `-std=c++17` is enabled. (`/std:c++17` for MSVC)
 
 You can also try the online version, PEG Playground at https://yhirose.github.io/cpp-peglib.
 

--- a/peglib.h
+++ b/peglib.h
@@ -37,7 +37,13 @@
 #include <unordered_set>
 #include <vector>
 
-#if !defined(__cplusplus) || __cplusplus < 201703L
+#if defined(_MSVC_LANG)
+#define PEG_CPLUSPLUS_VERSION _MSVC_LANG
+#elif defined(__cplusplus)
+#define PEG_CPLUSPLUS_VERSION __cplusplus
+#endif
+
+#if !defined(PEG_CPLUSPLUS_VERSION) || PEG_CPLUSPLUS_VERSION < 201703L
 #error "Requires complete C++17 support"
 #endif
 


### PR DESCRIPTION
I added a macro to test against _MSVC_LANG rather than __cplusplus under MSVC so windows users don't have to pass the `/Zc:__cplusplus` option. 