### PR TITLE
It fixes for compiling error on C++20.

### DIFF
--- a/peglib.h
+++ b/peglib.h
@@ -3320,8 +3320,8 @@ public:
   }
 
 #if defined(__cpp_lib_char8_t)
-  static bool parse_test(const char8_t *d, const char8_t *s) {
-    reutnr parse_test(reinterpret_cast<const char *>(s), s);
+  static bool parse_test(const char *d, const char8_t *s) {
+    return parse_test(d, reinterpret_cast<const char *>(s));
   }
 #endif
 


### PR DESCRIPTION
If it changes the version of CMAKE_CXX_STANDARD to 20, the following errors occurred by g++11.4.0.

````
In file included from ~/cpp-peglib/test/test1.cc:2:
~/cpp-peglib/test/../peglib.h: In static member function ‘static bool peg::ParserGenerator::parse_test(const char8_t*, const char8_t*)’:
~/cpp-peglib/test/../peglib.h:3324:5: error: ‘reutnr’ was not declared in this scope
 3324 |     reutnr parse_test(reinterpret_cast<const char *>(s), s);
      |     ^~~~~~
~/cpp-peglib/test/../peglib.h:3325:3: warning: no return statement in function returning non-void [-Wreturn-type]
 3325 |   }
      |   ^
~/cpp-peglib/test/../peglib.h:3323:41: warning: unused parameter ‘d’ [-Wunused-parameter]
 3323 |   static bool parse_test(const char8_t *d, const char8_t *s) {
      |                          ~~~~~~~~~~~~~~~^
~/cpp-peglib/test/../peglib.h:3323:59: warning: unused parameter ‘s’ [-Wunused-parameter]
 3323 |   static bool parse_test(const char8_t *d, const char8_t *s) {
      |                                            ~~~~~~~~~~~~~~~^
make[2]: *** [test/CMakeFiles/peglib-test-main.dir/build.make:76: test/CMakeFiles/peglib-test-main.dir/test1.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:152: test/CMakeFiles/peglib-test-main.dir/all] Error 2
````