### PR TITLE
Add missing <optional> include

### DIFF
--- a/peglib.h
+++ b/peglib.h
@@ -31,6 +31,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Adds the missing `<optional>` include to `peglib.h`.

Ref: Homebrew/homebrew-core#271855